### PR TITLE
Fix formatting of flushDeprecations.

### DIFF
--- a/tests/unit/deprecation-collector-test.js
+++ b/tests/unit/deprecation-collector-test.js
@@ -16,10 +16,16 @@ module("deprecation collector", {
 });
 
 test('calling flushDeprecations returns string of deprecations', (assert) => {
-  Ember.deprecate('Interesting');
+  Ember.deprecate('First deprecation');
+  Ember.deprecate('Second deprecation');
   let deprecationsPayload = window.deprecationWorkflow.flushDeprecations();
   assert.equal(deprecationsPayload, `window.deprecationWorkflow = window.deprecationWorkflow || {};
-window.deprecationWorkflow.config = {"workflow":[{"matchMessage":"Interesting","handler":"silence"}]};`);
+window.deprecationWorkflow.config = {
+  workflow: [
+    { matchMessage: \"First deprecation\", handler: \"silence\" },
+    { matchMessage: \"Second deprecation\", handler: \"silence\" }
+  ]
+};`);
 });
 
 test('deprecation silenced with string matcher', (assert) => {

--- a/vendor/ember-cli-deprecation-workflow/main.js
+++ b/vendor/ember-cli-deprecation-workflow/main.js
@@ -3,7 +3,7 @@
   window.deprecationWorkflow.deprecationLog = [];
 
   Ember.Debug.registerDeprecationHandler(function deprecationCollector(message, options, next){
-    window.deprecationWorkflow.deprecationLog.push({ matchMessage: message, handler: 'silence' });
+    window.deprecationWorkflow.deprecationLog.push('    { matchMessage: ' + JSON.stringify(message) + ', handler: "silence" }');
     next(message, options);
   });
 
@@ -47,14 +47,17 @@
 
   var preamble = [
     'window.deprecationWorkflow = window.deprecationWorkflow || {};',
-    'window.deprecationWorkflow.config = {"workflow":',
+    'window.deprecationWorkflow.config = {\n  workflow: [\n',
   ].join('\n');
 
   var postamble = [
-    '};'
+    '  ]\n};'
   ].join('\n');
 
   window.deprecationWorkflow.flushDeprecations = function flushDeprecations() {
-    return preamble+JSON.stringify(window.deprecationWorkflow.deprecationLog)+postamble;
+    var logs = window.deprecationWorkflow.deprecationLog;
+    var deprecations = logs.join(',\n') + '\n';
+
+    return preamble + deprecations + postamble;
   };
 })();


### PR DESCRIPTION
Make it much prettier :D

```javascript
window.deprecationWorkflow = window.deprecationWorkflow || {};
window.deprecationWorkflow.config = {
  workflow: [
    { matchMessage: \"First deprecation\", handler: \"silence\" },
    { matchMessage: \"Second deprecation\", handler: \"silence\" }
  ]
};
```

Addresses #1