### PR TITLE
Reorder workflow property order in flushDeprecations.

### DIFF
--- a/tests/unit/deprecation-collector-test.js
+++ b/tests/unit/deprecation-collector-test.js
@@ -22,8 +22,8 @@ test('calling flushDeprecations returns string of deprecations', (assert) => {
   assert.equal(deprecationsPayload, `window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
   workflow: [
-    { matchMessage: \"First deprecation\", handler: \"silence\" },
-    { matchMessage: \"Second deprecation\", handler: \"silence\" }
+    { handler: "silence", matchMessage: \"First deprecation\" },
+    { handler: "silence", matchMessage: \"Second deprecation\" }
   ]
 };`);
 });
@@ -40,8 +40,8 @@ test('deprecations are not duplicated', function(assert) {
   assert.equal(deprecationsPayload, `window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
   workflow: [
-    { matchMessage: \"First deprecation\", handler: \"silence\" },
-    { matchMessage: \"Second deprecation\", handler: \"silence\" }
+    { handler: "silence", matchMessage: \"First deprecation\" },
+    { handler: "silence", matchMessage: \"Second deprecation\" }
   ]
 };`);
 });

--- a/vendor/ember-cli-deprecation-workflow/main.js
+++ b/vendor/ember-cli-deprecation-workflow/main.js
@@ -5,7 +5,7 @@
   };
 
   Ember.Debug.registerDeprecationHandler(function deprecationCollector(message, options, next){
-    window.deprecationWorkflow.deprecationLog.messages[message] = '    { matchMessage: ' + JSON.stringify(message) + ', handler: "silence" }';
+    window.deprecationWorkflow.deprecationLog.messages[message] = '    { handler: "silence", matchMessage: ' + JSON.stringify(message) + ' }';
     next(message, options);
   });
 


### PR DESCRIPTION
Having the `handler` first, makes it much easier to scan the file and
tweak individual settings.