### PR TITLE
Add throwOnUnhandled config flag.

### DIFF
--- a/tests/unit/deprecation-collector-test.js
+++ b/tests/unit/deprecation-collector-test.js
@@ -21,6 +21,7 @@ test('calling flushDeprecations returns string of deprecations', (assert) => {
   let deprecationsPayload = window.deprecationWorkflow.flushDeprecations();
   assert.equal(deprecationsPayload, `window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
+  throwOnUnhandled: true,
   workflow: [
     { handler: "silence", matchMessage: \"First deprecation\" },
     { handler: "silence", matchMessage: \"Second deprecation\" }
@@ -39,11 +40,45 @@ test('deprecations are not duplicated', function(assert) {
   let deprecationsPayload = window.deprecationWorkflow.flushDeprecations();
   assert.equal(deprecationsPayload, `window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {
+  throwOnUnhandled: true,
   workflow: [
     { handler: "silence", matchMessage: \"First deprecation\" },
     { handler: "silence", matchMessage: \"Second deprecation\" }
   ]
 };`);
+});
+
+test('specifying `throwOnUnhandled` as true raises', function(assert) {
+  assert.expect(2);
+
+  Ember.ENV.RAISE_ON_DEPRECATION = false;
+
+  window.deprecationWorkflow.config = {
+    throwOnUnhandled: true,
+    workflow: [
+      { handler: 'silence', matchMessage: 'Sshhhhh!!' }
+    ]
+  };
+
+  assert.throws(function() {
+    Ember.deprecate('Foobarrrzzzz');
+  }, /Foobarrrzzzz/, 'setting raiseOnUnhandled throws for unknown workflows');
+
+  Ember.deprecate('Sshhhhh!!');
+  assert.ok(true, 'did not throw when silenced');
+});
+
+test('specifying `throwOnUnhandled` as false does nothing', function(assert) {
+  assert.expect(1);
+
+  Ember.ENV.RAISE_ON_DEPRECATION = false;
+
+  window.deprecationWorkflow.config = {
+    throwOnUnhandled: false
+  };
+
+  Ember.deprecate('Sshhhhh!!');
+  assert.ok(true, 'does not die when throwOnUnhandled is false');
 });
 
 test('deprecation silenced with string matcher', (assert) => {

--- a/vendor/ember-cli-deprecation-workflow/main.js
+++ b/vendor/ember-cli-deprecation-workflow/main.js
@@ -10,6 +10,10 @@
   });
 
   function detectWorkflow(config, message, options) {
+    if (!config || !config.workflow) {
+      return;
+    }
+
     var i, workflow, regex;
     for (i=0; i<config.workflow.length; i++) {
       workflow = config.workflow[i];
@@ -21,14 +25,15 @@
   }
 
   Ember.Debug.registerDeprecationHandler(function handleDeprecationWorkflow(message, options, next){
-    var config = window.deprecationWorkflow.config;
-    if (!config) {
-      return next(message, options);
-    }
+    var config = window.deprecationWorkflow.config || {};
 
     var matchingWorkflow = detectWorkflow(config, message, options);
     if (!matchingWorkflow) {
-      next(message, options);
+      if (config && config.throwOnUnhandled) {
+        throw new Error(message);
+      } else {
+        next(message, options);
+      }
     } else {
       switch(matchingWorkflow.handler) {
         case 'silence':
@@ -49,7 +54,7 @@
 
   var preamble = [
     'window.deprecationWorkflow = window.deprecationWorkflow || {};',
-    'window.deprecationWorkflow.config = {\n  workflow: [\n',
+    'window.deprecationWorkflow.config = {\n  throwOnUnhandled: true,\n  workflow: [\n',
   ].join('\n');
 
   var postamble = [


### PR DESCRIPTION
When set to truthy value, an error is thrown if the deprecation was not matched by one of the existing workflows.

This is very useful to ensure that no new deprecations are introduced that are not already known.