### PR TITLE
Ensure all deprecations are logged.

### DIFF
--- a/tests/unit/deprecation-collector-test.js
+++ b/tests/unit/deprecation-collector-test.js
@@ -154,3 +154,21 @@ test('deprecation thrown with regex matcher', (assert) => {
     Ember.deprecate('Interesting');
   }, 'deprecation throws');
 });
+
+test('deprecation logging happens even if `throwOnUnhandled` is true', function(assert) {
+  assert.expect(2);
+
+  Ember.ENV.RAISE_ON_DEPRECATION = false;
+
+  window.deprecationWorkflow.config = {
+    throwOnUnhandled: true
+  };
+
+  assert.throws(function() {
+    Ember.deprecate('Foobarrrzzzz');
+  }, /Foobarrrzzzz/, 'setting raiseOnUnhandled throws for unknown workflows');
+
+  let result = window.deprecationWorkflow.flushDeprecations();
+
+  assert.ok(/Foobarrrzzzz/.exec(result), 'unhandled deprecation was added to the deprecationLog');
+});

--- a/vendor/ember-cli-deprecation-workflow/main.js
+++ b/vendor/ember-cli-deprecation-workflow/main.js
@@ -4,11 +4,6 @@
     messages: { }
   };
 
-  Ember.Debug.registerDeprecationHandler(function deprecationCollector(message, options, next){
-    window.deprecationWorkflow.deprecationLog.messages[message] = '    { handler: "silence", matchMessage: ' + JSON.stringify(message) + ' }';
-    next(message, options);
-  });
-
   function detectWorkflow(config, message, options) {
     if (!config || !config.workflow) {
       return;
@@ -50,6 +45,11 @@
           break;
       }
     }
+  });
+
+  Ember.Debug.registerDeprecationHandler(function deprecationCollector(message, options, next){
+    window.deprecationWorkflow.deprecationLog.messages[message] = '    { handler: "silence", matchMessage: ' + JSON.stringify(message) + ' }';
+    next(message, options);
   });
 
   var preamble = [


### PR DESCRIPTION
The deprecationCollector **must** be first to ensure that even handled (or those that are thrown due to the `throwOnUnhandled` flag) are collected properly.