### PR TITLE
Ensure `deprecationManager.config` is present as early as possible.

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
     app.import('vendor/ember-cli-deprecation-workflow/main.js');
   },
   contentFor: function(type) {
-    if (type === 'app-prefix') {
+    if (type === 'vendor-prefix') {
       // FIXME: This should be excluded in production
       var fs = require('fs');
       var path = require('path');


### PR DESCRIPTION
This ensures that as soon as the deprecation manager is loaded, we can begin handling deprecations (previously we waited until the app bundle was loaded and received more deprecations from vendor).