### PR TITLE
Only include helpers while running with tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 
 env:
   - EMBER_TRY_SCENARIO=default
+  - EMBER_ENV=production EMBER_TRY_SCENARIO=default
   - EMBER_TRY_SCENARIO=ember-release
   - EMBER_TRY_SCENARIO=ember-beta
   - EMBER_TRY_SCENARIO=ember-canary

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,8 +1,9 @@
 /* global require, module */
+var path = require('path');
 var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
 
 // Ensures tests can find the dummy app config directory
-process.env.USE_DUMMY_CONFIG = true;
+process.env._DUMMY_CONFIG_ROOT_PATH = path.join(__dirname, 'tests', 'dummy');
 
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {

--- a/index.js
+++ b/index.js
@@ -3,34 +3,35 @@
 
 module.exports = {
   name: 'ember-cli-deprecation-workflow',
+
+  _shouldInclude: function() {
+    // the presence of `this.app.tests` shows that we are in one of:
+    //
+    // * running non-production build
+    // * running tests against production
+    //
+    return this.app.tests;
+  },
+
   included: function() {
     // From https://github.com/rwjblue/ember-debug-handlers-polyfill/blob/master/index.js
     var app = this.app;
 
-    if (app.env !== 'production') {
+    if (this._shouldInclude()) {
       app.import('vendor/ember-debug-handlers-polyfill/debug.js');
+      app.import('vendor/ember-cli-deprecation-workflow/main.js');
     } else {
       app.import('vendor/ember-debug-handlers-polyfill/prod.js');
     }
-
-    // FIXME: This should be excluded in production
-    app.import('vendor/ember-cli-deprecation-workflow/main.js');
   },
   contentFor: function(type) {
-    if (type === 'vendor-prefix') {
-      // FIXME: This should be excluded in production
+    if (this._shouldInclude() && type === 'vendor-prefix') {
       var fs = require('fs');
       var path = require('path');
       var existsSync = require('exists-sync');
-      var root, configPath;
-      if (process.env.USE_DUMMY_CONFIG) {
-        // Ensures tests can find the dummy app config directory
-        root = this.app.options.configPath;
-        configPath = path.join(root, '..', 'deprecation-workflow.js');
-      } else {
-        root = this.project.root;
-        configPath = path.join(root, 'config', 'deprecation-workflow.js');
-      }
+      var root = process.env._DUMMY_CONFIG_ROOT_PATH || this.project.root;
+      var configPath = path.join(root, 'config', 'deprecation-workflow.js');
+
       if (existsSync(configPath)) {
         return fs.readFileSync(configPath);
       }


### PR DESCRIPTION
This still allows deprecation handlers to be present in production builds when ran with the `ember test` command since users may be relying on the deprecation manager to be present when running their test suites against a production database.

Fixes #16.