### PR TITLE
Add support for `idMatch`

### DIFF
--- a/tests/acceptance/workflow-config-test.js
+++ b/tests/acceptance/workflow-config-test.js
@@ -35,3 +35,14 @@ test('deprecation thrown with string matcher', (assert) => {
     Ember.deprecate('throw-me');
   }, 'deprecation throws');
 });
+
+test('deprecation logs with id matcher', (assert) => {
+  assert.expect(1);
+
+  let message = 'log-id',
+    options = { id: 'ember.workflow', until: '3.0.0' };
+  Ember.Logger.warn = function(passedMessage) {
+    assert.equal(passedMessage, 'DEPRECATION: ' + message, 'deprecation logs');
+  };
+  Ember.deprecate(message, false, options);
+});

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -2,5 +2,6 @@ window.deprecationWorkflow = window.deprecationWorkflow || {};
 window.deprecationWorkflow.config = {"workflow":[
   { matchMessage: 'silence-me', handler: 'silence' },
   { matchMessage: 'log-me', handler: 'log' },
-  { matchMessage: 'throw-me', handler: 'throw' }
+  { matchMessage: 'throw-me', handler: 'throw' },
+  { matchId: 'ember.workflow', handler: 'log' }
 ]};

--- a/tests/unit/deprecation-collector-test.js
+++ b/tests/unit/deprecation-collector-test.js
@@ -167,6 +167,46 @@ test('deprecation thrown with string matcher', (assert) => {
   }, 'deprecation throws');
 });
 
+test('deprecation silenced with id matcher', (assert) => {
+  Ember.ENV.RAISE_ON_DEPRECATION = true;
+  window.deprecationWorkflow.config = {
+    workflow: [
+      { matchId: 'ember.deprecation-workflow', handler: 'silence' }
+    ]
+  };
+  Ember.deprecate('Slightly interesting', false,
+                  { id: 'ember.deprecation-workflow', until: '3.0.0' });
+  assert.ok(true, 'Deprecation did not raise');
+});
+
+test('deprecation logs with id matcher', (assert) => {
+  assert.expect(1);
+
+  let message = 'Slightly interesting';
+  Ember.Logger.warn = function(passedMessage) {
+    assert.equal(passedMessage, 'DEPRECATION: ' + message, 'deprecation logs');
+  };
+  window.deprecationWorkflow.config = {
+    workflow: [
+      { matchId: 'ember.deprecation-workflow', handler: 'log' }
+    ]
+  };
+  Ember.deprecate('Slightly interesting', false,
+                  { id: 'ember.deprecation-workflow', until: '3.0.0' });
+});
+
+test('deprecation thrown with id matcher', (assert) => {
+  window.deprecationWorkflow.config = {
+    workflow: [
+      { matchId: 'ember.deprecation-workflow', handler: 'throw' }
+    ]
+  };
+  assert.throws(function() {
+    Ember.deprecate('Slightly interesting', false,
+                    { id: 'ember.deprecation-workflow', until: '3.0.0' });
+  }, 'deprecation throws');
+});
+
 test('deprecation logging happens even if `throwOnUnhandled` is true', function(assert) {
   assert.expect(2);
 

--- a/vendor/ember-cli-deprecation-workflow/main.js
+++ b/vendor/ember-cli-deprecation-workflow/main.js
@@ -9,14 +9,17 @@
       return;
     }
 
-    var i, workflow, regex, matcher;
+    var i, workflow, regex, matcher, idMatcher;
     for (i=0; i<config.workflow.length; i++) {
       workflow = config.workflow[i];
       matcher = workflow.matchMessage;
+      idMatcher = workflow.matchId;
 
       if (typeof matcher === 'string' && matcher === message) {
         return workflow;
       } else if (matcher instanceof RegExp && matcher.exec(message)) {
+        return workflow;
+      } else if (typeof idMatcher === 'string' && options && idMatcher === options.id) {
         return workflow;
       }
     }

--- a/vendor/ember-cli-deprecation-workflow/main.js
+++ b/vendor/ember-cli-deprecation-workflow/main.js
@@ -15,11 +15,11 @@
       matcher = workflow.matchMessage;
       idMatcher = workflow.matchId;
 
-      if (typeof matcher === 'string' && matcher === message) {
+      if (typeof idMatcher === 'string' && options && idMatcher === options.id) {
+        return workflow;
+      } else if (typeof matcher === 'string' && matcher === message) {
         return workflow;
       } else if (matcher instanceof RegExp && matcher.exec(message)) {
-        return workflow;
-      } else if (typeof idMatcher === 'string' && options && idMatcher === options.id) {
         return workflow;
       }
     }


### PR DESCRIPTION
Can now match deprecations based on the `id` passed in the options
to `deprecate`.

Fixes #3.