### PR TITLE
Include template deprecations processing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,23 @@ There are 3 defined handlers that have different behaviors
 
 the output from running `deprecationWorkflow.flushDeprecations()` gives you a nice Json like JS object with all the deprecations in your app. The `matchMessage` property determines what to filter out of the console. You can pass a string that must match the console message exactly or a `RegExp` for `ember-cli-deprecation-workflow` filter the log by.
 
+### Template Deprecations
+
+By default, the console based deprecations that occur during template compilation
+are suppressed in favor of browser deprecations ran during the test suite. If you
+would prefer to still have the deprecations in the console, add the following to
+your `config/environment.js`:
+
+```javascript
+module.exports = function(env) {
+  var ENV = { };
+
+  // normal things here
+
+  ENV.logTemplateLintToConsole = true;
+}
+```
+
 ## Contributing
 
 Details on contributing to the addon itself (not required for normal usage).

--- a/generate-deprecations-tree.js
+++ b/generate-deprecations-tree.js
@@ -1,0 +1,48 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var rimraf = require('rimraf');
+var quickTemp = require('quick-temp');
+var hashStrings = require('broccoli-kitchen-sink-helpers').hashStrings;
+
+function TemplateLinter(deprecationSource) {
+  this.description = 'TemplateLinter';
+  this.deprecationSource = deprecationSource;
+  this.lastHash = undefined;
+}
+
+TemplateLinter.prototype.content = function() {
+  return this.deprecationSource._templateDeprecations
+    .map(function(item) {
+      return 'Ember.deprecate(\n' +
+        '  ' + item.message + ',\n' +
+        '  ' + item.test + ',\n' +
+        '  ' + item.options + '\n' +
+        ');';
+    })
+    .join('\n');
+};
+
+TemplateLinter.prototype.read = function() {
+  var dir = quickTemp.makeOrReuse(this, 'template-linter-cache');
+
+  var outputPath = path.join(dir, 'template-deprecations-test.js');
+
+  var content = this.content();
+  var hash = hashStrings([content]);
+
+  if (this.lastHash !== hash) {
+    this.lastHash = hash;
+    fs.writeFileSync(outputPath, content);
+  }
+
+  return dir;
+};
+
+TemplateLinter.prototype.cleanup = function() {
+  return rimraf.sync(this['template-linter-cache']);
+};
+
+
+module.exports = TemplateLinter;

--- a/index.js
+++ b/index.js
@@ -52,6 +52,11 @@ module.exports = {
   },
 
   _monkeyPatch_EmberDeprecate: function(htmlbarsCompilerPreprocessor) {
+    if (!htmlbarsCompilerPreprocessor._addon) {
+      // not a new enough ember-cli-htmlbars to monkey patch
+      // we need 1.0.3
+      return;
+    }
     var addonContext = this;
     var originalHtmlbarsOptions = htmlbarsCompilerPreprocessor._addon.htmlbarsOptions;
     var logToNodeConsole = this.project.config(process.env.EMBER_ENV).logTemplateLintToConsole;

--- a/package.json
+++ b/package.json
@@ -42,11 +42,15 @@
   ],
   "dependencies": {
     "broccoli-funnel": "^1.0.1",
+    "broccoli-kitchen-sink-helpers": "^0.3.1",
     "broccoli-merge-trees": "^1.1.1",
     "ember-cli-babel": "^5.1.5",
-    "ember-debug-handlers-polyfill": "^1.0.2"
+    "ember-debug-handlers-polyfill": "^1.0.2",
+    "quick-temp": "^0.1.5",
+    "rimraf": "^2.5.2"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-cli-htmlbars"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ember-cli": "2.3.0",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.1",
+    "ember-cli-htmlbars": "^1.0.3",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",
     "ember-cli-qunit": "^1.2.1",


### PR DESCRIPTION
This will be removed from ember-cli-template-lint once this lands and is released...