### PR TITLE
CoreObject 1.x and 2.x Compat

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ module.exports = {
   name: 'ember-cli-deprecation-workflow',
 
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
+    
     this._templateDeprecations = [];
   },
 


### PR DESCRIPTION
Hi,

This should fix the deprecation

```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-deprecation-workflow`
```

which is now displayed when running `ember` commands using ember-cli > 2.6

Thanks