### PR TITLE
document production builds and catch-all

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ By default, production ember-cli builds already remove deprecation warnings. Any
 
 ### Catch-all
 
-To force all deprecations to throw (can be useful in larger teams to prevent accidental introduction of deprecations)
+To force all deprecations to throw (can be useful in larger teams to prevent accidental introduction of deprecations), update your `config/deprecation-workflow.js`:
 ```javascript
 window.deprecationWorkflow.config = {
   throwOnUnhandled: true

--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ There are 3 defined handlers that have different behaviors
 
 the output from running `deprecationWorkflow.flushDeprecations()` gives you a nice Json like JS object with all the deprecations in your app. The `matchMessage` property determines what to filter out of the console. You can pass a string that must match the console message exactly or a `RegExp` for `ember-cli-deprecation-workflow` filter the log by.
 
+### Production builds
+
+By default, production ember-cli builds already remove deprecation warnings. Any deprecations configured to `throw` or `log` will only do so in non-production builds.
+
+### Catch-all
+
+To force all deprecations to throw (can be useful in larger teams to prevent accidental introduction of deprecations)
+```javascript
+window.deprecationWorkflow.config = {
+  throwOnUnhandled: true
+}
+```
+
 ### Template Deprecations
 
 By default, the console based deprecations that occur during template compilation


### PR DESCRIPTION
These two sections in the `readme` would have been very useful to me, hopefully others find it useful. It was not obvious to me production builds would not `log` or `throw` until I looked through the source code.  While looking at the source code, I found tests for `throwOnUnhandled` which I found extremely useful. I work on a large team, and not everyone is deeply experienced in Ember. There is nothing preventing warnings from finding their way into the logs.  Someone on the team referenced an old stack overflow answer which introduced a deprecation. Now that we have zero deprecation warnings, we want to keep it that way by forcing tests to fail.