### PR TITLE
Allow custom addon config directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,20 @@ module.exports = function(env) {
 }
 ```
 
+### Configuration
+
+In some cases, it may be necessary to indicate a different `config` directory from the default one (`/config`). For example, you may want the flushed deprecations file to be referenced in a config directory like `my-config`.
+
+Adjust the `configPath` in your `package.json` file. The `/` will automatically be prefixed.
+
+```javascript
+{
+  'ember-addon': {
+    configPath: 'my-config'
+  }
+}
+```
+
 ## Contributing
 
 Details on contributing to the addon itself (not required for normal usage).

--- a/index.js
+++ b/index.js
@@ -33,9 +33,15 @@ module.exports = {
 
   treeForVendor: function(tree) {
     var root = process.env._DUMMY_CONFIG_ROOT_PATH || this.project.root;
+    var configDir = '/config';
+
+    if (this.project.pkg['ember-addon'] && this.project.pkg['ember-addon']['configPath']) {
+      configDir = '/' + this.project.pkg['ember-addon']['configPath'];
+    }
+
     var mergeTrees = require('broccoli-merge-trees');
     var Funnel = require('broccoli-funnel');
-    var configTree = new Funnel(root + '/config', {
+    var configTree = new Funnel(root + configDir, {
       include: ['deprecation-workflow.js'],
 
       destDir: 'ember-cli-deprecation-workflow'

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
-    "configPath": "config",
+    "configPath": "tests/dummy/config",
     "after": "ember-cli-htmlbars"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "node": "6.* || 8.* || >= 10.*"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config",
+    "configPath": "config",
     "after": "ember-cli-htmlbars"
   }
 }


### PR DESCRIPTION
Some application setups may use alternative `config` directories.

To customize, in app's `ember-cli-build`, add an entry under `options` for this addon:

```js
const options = {
  'ember-cli-deprecation-workflow': {
    configDir: '/my-config'
  }
}
```