### PR TITLE
Update broccoli node to be broccoli-plugin based.

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,9 +116,11 @@ module.exports = {
     }
   },
 
-  lintTree: function() {
-    var TemplateLinter = require('./generate-deprecations-tree');
+  lintTree: function(type, tree) {
+    if (type === 'template') {
+      var TemplateLinter = require('./generate-deprecations-tree');
 
-    return new TemplateLinter(this);
+      return new TemplateLinter(this, tree);
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -21,12 +21,10 @@
     "test:all": "ember try:each"
   },
   "dependencies": {
-    "broccoli-funnel": "^1.0.1",
-    "broccoli-kitchen-sink-helpers": "^0.3.1",
-    "broccoli-merge-trees": "^1.1.1",
-    "ember-debug-handlers-polyfill": "^1.0.2",
-    "quick-temp": "^0.1.5",
-    "rimraf": "^2.5.2"
+    "broccoli-funnel": "^2.0.1",
+    "broccoli-merge-trees": "^3.0.1",
+    "broccoli-plugin": "^1.3.1",
+    "ember-debug-handlers-polyfill": "^1.1.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,7 +1126,7 @@ broccoli-lint-eslint@^4.2.1:
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.1:
+broccoli-merge-trees@^1.0.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -1146,7 +1146,7 @@ broccoli-merge-trees@^2.0.0:
     broccoli-plugin "^1.3.0"
     merge-trees "^1.0.1"
 
-broccoli-merge-trees@^3.0.0:
+broccoli-merge-trees@^3.0.0, broccoli-merge-trees@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-3.0.1.tgz#545dfe9f695cec43372b3ee7e63c7203713ea554"
   dependencies:
@@ -1208,7 +1208,7 @@ broccoli-plugin@1.1.0:
     rimraf "^2.3.4"
     symlink-or-copy "^1.0.1"
 
-broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0:
+broccoli-plugin@^1.0.0, broccoli-plugin@^1.2.0, broccoli-plugin@^1.2.1, broccoli-plugin@^1.3.0, broccoli-plugin@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz#a26315732fb99ed2d9fb58f12a1e14e986b4fabd"
   dependencies:
@@ -2166,7 +2166,7 @@ ember-cli@~3.4.3:
     watch-detector "^0.1.0"
     yam "^0.0.24"
 
-ember-debug-handlers-polyfill@^1.0.2:
+ember-debug-handlers-polyfill@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ember-debug-handlers-polyfill/-/ember-debug-handlers-polyfill-1.1.1.tgz#e9ae0a720271a834221179202367421b580002ef"
 
@@ -5246,7 +5246,7 @@ ret@~0.1.10:
   version "0.1.15"
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
-rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.2, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
+rimraf@^2.2.8, rimraf@^2.3.2, rimraf@^2.3.4, rimraf@^2.4.3, rimraf@^2.4.4, rimraf@^2.5.3, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:


### PR DESCRIPTION
Silences the `.read` / `.rebuild` API deprecation.

Fixes https://github.com/mixonic/ember-cli-deprecation-workflow/issues/52