### PR TITLE
Add Ember 1.13, 2.4, 2.8, and 2.12 back into config/ember-try.js.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ addons:
   chrome: stable
 
 cache:
-  directories:
-    - $HOME/.npm
+  yarn: true
 
 env:
   global:
@@ -31,14 +30,24 @@ jobs:
     - stage: "Tests"
       name: "Tests"
       script:
-        - npm run lint:hbs
-        - npm run lint:js
-        - npm test
+        - yarn lint:hbs
+        - yarn lint:js
+        - yarn test
+    - name: "Floating Dependencies"
+      install:
+        - yarn install --no-lockfile --non-interactive
+      script:
+        - yarn test
+
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-2.16
+      env: EMBER_TRY_SCENARIO=ember-1.13
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.4
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.8
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.12
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.16
     - env: EMBER_TRY_SCENARIO=ember-lts-2.18
     - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
@@ -46,9 +55,11 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
 
 before_install:
-  - npm config set spin false
-  - npm install -g npm@4
-  - npm --version
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+
+install:
+  - yarn install --non-interactive
 
 script:
-  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO
+  - yarn ember try:one $EMBER_TRY_SCENARIO

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -9,7 +9,82 @@ module.exports = function() {
     getChannelURL('canary')
   ]).then((urls) => {
     return {
+      useYarn: true,
       scenarios: [
+        {
+          name: 'ember-1.13',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
+          bower: {
+            dependencies: {
+              ember: '~1.13.0',
+            },
+            resolutions: {
+              ember: '~1.13.0',
+            },
+          },
+          npm: {
+            devDependencies: {
+              '@ember/jquery': '^0.5.1',
+              'ember-source': null,
+              'jquery': '^1.11.1',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-2.4',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
+          bower: {
+            dependencies: {
+              ember: 'components/ember#lts-2-4',
+            },
+            resolutions: {
+              ember: 'lts-2-4',
+            },
+          },
+          npm: {
+            devDependencies: {
+              '@ember/jquery': '^0.5.1',
+              'ember-source': null,
+              'jquery': '^1.11.1',
+            },
+          },
+        },
+        {
+          name: 'ember-lts-2.8',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
+          bower: {
+            dependencies: {
+              ember: 'components/ember#lts-2-8',
+            },
+            resolutions: {
+              ember: 'lts-2-8',
+            },
+          },
+          npm: {
+            devDependencies: {
+              '@ember/jquery': '^0.5.1',
+              'ember-source': null,
+            },
+          },
+        },
+        {
+          name: 'ember-lts-2.12',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
+          npm: {
+            devDependencies: {
+              '@ember/jquery': '^0.5.1',
+              'ember-source': '~2.12.0',
+            },
+          },
+        },
         {
           name: 'ember-lts-2.16',
           env: {
@@ -30,6 +105,14 @@ module.exports = function() {
           npm: {
             devDependencies: {
               '@ember/jquery': '^0.5.1',
+              'ember-source': '~2.18.0'
+            }
+          }
+        },
+        {
+          name: 'ember-lts-3.4',
+          npm: {
+            devDependencies: {
               'ember-source': '~2.18.0'
             }
           }


### PR DESCRIPTION
Adding these versions back to ember-try config for now, we may still decide to drop ember@1.13 support but I wanted to maintain support for now.