### PR TITLE
this.app is not always present

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,12 +15,13 @@ module.exports = {
     // * running non-production build
     // * running tests against production
     //
-    return this.app.tests;
+    var app = this.app || this._findHost();
+    return app.tests;
   },
 
   included: function() {
     // From https://github.com/rwjblue/ember-debug-handlers-polyfill/blob/master/index.js
-    var app = this.app;
+    var app = this.app || this._findHost();
 
     if (this._shouldInclude()) {
       app.import('vendor/ember-debug-handlers-polyfill/debug.js');


### PR DESCRIPTION
If `ember-cli-deprecation-workflow` is not in top-level dependency `this.app` will throw following error,
```
TypeError: Cannot read property 'tests' of undefined
    at Class._shouldInclude (/Users/snrai/Projects/test-addon/node_modules/ember-cli-deprecation-workflow/index.js:19:21)
```
This fix will check if there is an `app` in `this` if not then fetch the `app` using `this._findHost` function.