### PR TITLE
Config option for enabling/disabling the add-on.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ the output from running `deprecationWorkflow.flushDeprecations()` gives you a ni
 
 By default, production ember-cli builds already remove deprecation warnings. Any deprecations configured to `throw` or `log` will only do so in non-production builds.
 
+### Enable / Disable through configuration
+
+If your app has disabled test files in development environment you can force enabling this addon through configuration in `ember-cli-build.js` instead:
+```javascript
+'ember-cli-deprecation-workflow': {
+  enabled: true,
+},
+```
+
 ### Catch-all
 
 To force all deprecations to throw (can be useful in larger teams to prevent accidental introduction of deprecations), update your `config/deprecation-workflow.js`:

--- a/index.js
+++ b/index.js
@@ -16,7 +16,13 @@ module.exports = {
     // * running tests against production
     //
     var app = this.app || this._findHost();
-    return app.tests;
+    let addonOptions = app.options['ember-cli-deprecation-workflow'];
+
+    if (addonOptions) {
+      return addonOptions.enabled;
+    } else {
+      return app.tests;
+    }
   },
 
   included: function() {


### PR DESCRIPTION
This allows the addon to be enabled / disabled through configuration in `ember-cli-build.js`:
```js
'ember-cli-deprecation-workflow': {
  enabled: true,
},
```

Useful when your app doesn't include test files in the development environment.

Based on @GavinJoyce's [fork](https://github.com/intercom/ember-cli-deprecation-workflow/pull/1).