### PR TITLE
Address a deprecated import path for deprecate in tests

### DIFF
--- a/tests/acceptance/workflow-config-test.js
+++ b/tests/acceptance/workflow-config-test.js
@@ -1,4 +1,4 @@
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug';
 import Ember from 'ember';
 import { module } from 'qunit';
 import test from '../helpers/debug-test';

--- a/tests/unit/deprecation-collector-test.js
+++ b/tests/unit/deprecation-collector-test.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 0 */
 
-import { deprecate } from '@ember/application/deprecations';
+import { deprecate } from '@ember/debug';
 import Ember from 'ember';
 import { module } from 'qunit';
 import test from '../helpers/debug-test';


### PR DESCRIPTION
Addresses failing tests for the release/beta/canary channels of Ember.