### PR TITLE
Drop debug handler polyfill

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,13 +24,10 @@ module.exports = {
     var app = this.app || this._findHost();
 
     if (this._shouldInclude()) {
-      app.import('vendor/ember-debug-handlers-polyfill/debug.js');
       app.import(
         'vendor/ember-cli-deprecation-workflow/deprecation-workflow.js'
       );
       app.import('vendor/ember-cli-deprecation-workflow/main.js');
-    } else {
-      app.import('vendor/ember-debug-handlers-polyfill/prod.js');
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
     "broccoli-funnel": "^3.0.3",
     "broccoli-merge-trees": "^4.2.0",
     "broccoli-plugin": "^4.0.5",
-    "ember-cli-htmlbars": "^5.3.2",
-    "ember-debug-handlers-polyfill": "^1.1.1"
+    "ember-cli-htmlbars": "^5.3.2"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5539,10 +5539,6 @@ ember-compatibility-helpers@^1.1.2:
     ember-cli-version-checker "^5.1.1"
     semver "^5.4.1"
 
-ember-debug-handlers-polyfill@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/ember-debug-handlers-polyfill/-/ember-debug-handlers-polyfill-1.1.1.tgz#e9ae0a720271a834221179202367421b580002ef"
-
 ember-disable-prototype-extensions@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/ember-disable-prototype-extensions/-/ember-disable-prototype-extensions-1.1.3.tgz#1969135217654b5e278f9fe2d9d4e49b5720329e"


### PR DESCRIPTION
This dependency is only required for Ember versions through 2.1, however
on master support for pre-2.12 has been dropped.

Fixes #113