### PR TITLE
Fix qunit interface

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -21,13 +21,6 @@
     {{content-for "body"}}
     {{content-for "test-body"}}
 
-    <div id="qunit"></div>
-    <div id="qunit-fixture">
-      <div id="ember-testing-container">
-        <div id="ember-testing"></div>
-      </div>
-    </div>
-
     <script src="/testem.js" integrity=""></script>
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/test-support.js"></script>


### PR DESCRIPTION
Remove extraneous qunit-fixture until ember-qunit gets major version bump

These elements were introduced in #92 as part of ember-qunit upgrade but ember-qunit was reverted in #110 which made interface QUnit interface unusable (technically extra div covers everything on screen).