### PR TITLE
Clean up test config for clarity

### DIFF
--- a/tests/acceptance/workflow-config-test.js
+++ b/tests/acceptance/workflow-config-test.js
@@ -1,5 +1,4 @@
 import { deprecate } from '@ember/debug';
-import Ember from 'ember';
 import { module } from 'qunit';
 import test from '../helpers/debug-test';
 
@@ -11,13 +10,12 @@ module('workflow config', function (hooks) {
   });
 
   hooks.afterEach(function () {
-    Ember.ENV.RAISE_ON_DEPRECATION = false;
     window.deprecationWorkflow.deprecationLog = { messages: {} };
     window.Testem.handleConsoleMessage = originalWarn;
   });
 
   test('deprecation silenced with string matcher', (assert) => {
-    deprecate('silence-me', false, {
+    deprecate('silence-strict', false, {
       since: '2.0.0',
       until: 'forever',
       id: 'test',
@@ -26,10 +24,10 @@ module('workflow config', function (hooks) {
     assert.ok(true, 'Deprecation did not raise');
   });
 
-  test('deprecation logs with string matcher', (assert) => {
+  test('deprecation logs with message matcher', (assert) => {
     assert.expect(1);
 
-    let message = 'log-me';
+    let message = 'log-strict';
     window.Testem.handleConsoleMessage = function (passedMessage) {
       assert.ok(
         passedMessage.indexOf('DEPRECATION: ' + message) === 0,
@@ -44,10 +42,45 @@ module('workflow config', function (hooks) {
     });
   });
 
+  test('deprecation logs with message matcher by regex', (assert) => {
+    assert.expect(1);
+
+    let message = ' foo log-match foo';
+    window.Testem.handleConsoleMessage = function (passedMessage) {
+      assert.ok(
+        passedMessage.indexOf('DEPRECATION: ' + message) === 0,
+        'deprecation logs'
+      );
+    };
+    deprecate(message, false, {
+      since: 'now',
+      until: 'forever',
+      id: 'test',
+      for: 'testing',
+    });
+  });
+
+  test('deprecation logs with id matcher', (assert) => {
+    assert.expect(1);
+
+    let message = ' foo foo';
+    window.Testem.handleConsoleMessage = function (passedMessage) {
+      assert.ok(
+        passedMessage.indexOf('DEPRECATION: ' + message) === 0,
+        'deprecation logs'
+      );
+    };
+    deprecate(message, false, {
+      since: 'now',
+      until: 'forever',
+      id: 'log-strict',
+      for: 'testing',
+    });
+  });
+
   test('deprecation thrown with string matcher', (assert) => {
-    Ember.ENV.RAISE_ON_DEPRECATION = true;
     assert.throws(function () {
-      deprecate('throw-me', false, {
+      deprecate('throw-strict', false, {
         since: '2.0.0',
         until: 'forever',
         id: 'test',
@@ -60,7 +93,7 @@ module('workflow config', function (hooks) {
     assert.expect(1);
 
     let message = 'arbitrary-unmatched-message';
-    let id = 'log-me';
+    let id = 'log-strict';
     let options = {
       id,
       since: '2.0.0',
@@ -82,7 +115,7 @@ module('workflow config', function (hooks) {
     assert.expect(104);
     let limit = 100;
 
-    let message = 'log-me';
+    let message = 'log-match';
     let id = 'first-and-unique-to-limit-test';
     let options = {
       id,
@@ -119,7 +152,7 @@ module('workflow config', function (hooks) {
 
     assert.equal(count, limit, 'logged 100 times, including final notice');
 
-    let secondMessage = 'log-me';
+    let secondMessage = 'log-strict';
     let secondId = 'second-and-unique-to-limit-test';
     let secondOptions = {
       id: secondId,

--- a/tests/dummy/config/deprecation-workflow.js
+++ b/tests/dummy/config/deprecation-workflow.js
@@ -1,10 +1,25 @@
 /* globals self */
 self.deprecationWorkflow = self.deprecationWorkflow || {};
 self.deprecationWorkflow.config = {
+  throwOnUnhandled: true,
   workflow: [
-    { matchMessage: 'silence-me', handler: 'silence' },
-    { matchMessage: 'log-me', handler: 'log' },
-    { matchMessage: 'throw-me', handler: 'throw' },
-    { matchId: 'log-me', handler: 'log' },
+    /*
+     * Actual controlled deprecations
+     */
+    { matchId: 'ember-global', handler: 'log' },
+    { matchId: 'ember.component.reopen', handler: 'log' },
+
+    /*
+     * Deprecation setup for tests
+     */
+    { matchId: 'silence-strict', handler: 'silence' },
+    { matchMessage: 'silence-strict', handler: 'silence' },
+    { matchMessage: /silence-match/, handler: 'silence' },
+
+    { matchId: 'log-strict', handler: 'log' },
+    { matchMessage: 'log-strict', handler: 'log' },
+    { matchMessage: /log-match/, handler: 'log' },
+
+    { matchMessage: 'throw-strict', handler: 'throw' },
   ],
 };

--- a/tests/unit/deprecation-collector-test.js
+++ b/tests/unit/deprecation-collector-test.js
@@ -1,20 +1,24 @@
 /* eslint no-console: 0 */
 
 import { deprecate } from '@ember/debug';
-import Ember from 'ember';
 import { module } from 'qunit';
 import test from '../helpers/debug-test';
 
-let originalWarn;
+let originalWarn, originalConfig;
 
 module('deprecation collector', function (hooks) {
   hooks.beforeEach(function () {
     originalWarn = console.warn;
+
+    /*
+     * Clear config for these tests
+     */
+    originalConfig = self.deprecationWorkflow.config;
+    self.deprecationWorkflow.config = null;
   });
 
   hooks.afterEach(function () {
-    Ember.ENV.RAISE_ON_DEPRECATION = false;
-    self.deprecationWorkflow.config = null;
+    self.deprecationWorkflow.config = originalConfig;
     self.deprecationWorkflow.deprecationLog = { messages: {} };
     console.warn = originalWarn;
   });
@@ -43,16 +47,6 @@ self.deprecationWorkflow.config = {
   ]
 };`
     );
-  });
-
-  test('deprecation does not choke when called without soon-to-be-required options', (assert) => {
-    deprecate('silence-me', undefined, {
-      id: 'silence-me',
-      since: 'the beginning',
-      until: 'forever',
-      for: 'testing',
-    });
-    assert.ok(true, 'Deprecation did not raise');
   });
 
   test('deprecations are not duplicated', function (assert) {
@@ -99,8 +93,6 @@ self.deprecationWorkflow.config = {
   test('specifying `throwOnUnhandled` as true raises', function (assert) {
     assert.expect(2);
 
-    Ember.ENV.RAISE_ON_DEPRECATION = false;
-
     self.deprecationWorkflow.config = {
       throwOnUnhandled: true,
       workflow: [{ handler: 'silence', matchMessage: 'Sshhhhh!!' }],
@@ -131,8 +123,6 @@ self.deprecationWorkflow.config = {
   test('specifying `throwOnUnhandled` as false does nothing', function (assert) {
     assert.expect(1);
 
-    Ember.ENV.RAISE_ON_DEPRECATION = false;
-
     self.deprecationWorkflow.config = {
       throwOnUnhandled: false,
     };
@@ -147,7 +137,6 @@ self.deprecationWorkflow.config = {
   });
 
   test('deprecation silenced with string matcher', (assert) => {
-    Ember.ENV.RAISE_ON_DEPRECATION = true;
     self.deprecationWorkflow.config = {
       workflow: [{ matchMessage: 'Interesting', handler: 'silence' }],
     };
@@ -196,7 +185,6 @@ self.deprecationWorkflow.config = {
   });
 
   test('deprecation silenced with regex matcher', (assert) => {
-    Ember.ENV.RAISE_ON_DEPRECATION = true;
     self.deprecationWorkflow.config = {
       workflow: [{ matchMessage: /Inter/, handler: 'silence' }],
     };
@@ -264,7 +252,6 @@ self.deprecationWorkflow.config = {
   });
 
   test('deprecation silenced with id matcher', (assert) => {
-    Ember.ENV.RAISE_ON_DEPRECATION = true;
     self.deprecationWorkflow.config = {
       workflow: [{ matchId: 'ember.deprecation-workflow', handler: 'silence' }],
     };
@@ -315,8 +302,6 @@ self.deprecationWorkflow.config = {
 
   test('deprecation logging happens even if `throwOnUnhandled` is true', function (assert) {
     assert.expect(2);
-
-    Ember.ENV.RAISE_ON_DEPRECATION = false;
 
     self.deprecationWorkflow.config = {
       throwOnUnhandled: true,


### PR DESCRIPTION
Remove a test for "modern" arguments which are now just used through the whole codebase. Cause the test suite to throw when an unhandled exception is encountered.

Remove all use RAISE_ON_DEPRECATION stuff, as this addon has its own configuration for throwing on unhandled deprecation which should be under test here.

Extracted from https://github.com/mixonic/ember-cli-deprecation-workflow/pull/118