### PR TITLE
Move ember-cli-htmlbars to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
   "dependencies": {
     "broccoli-funnel": "^3.0.3",
     "broccoli-merge-trees": "^4.2.0",
-    "broccoli-plugin": "^4.0.5",
-    "ember-cli-htmlbars": "^5.3.2"
+    "broccoli-plugin": "^4.0.5"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -43,6 +42,7 @@
     "ember-cli": "~3.25.0",
     "ember-cli-babel": "^7.26.6",
     "ember-cli-dependency-checker": "^3.2.0",
+    "ember-cli-htmlbars": "^5.3.2",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-terser": "^4.0.1",


### PR DESCRIPTION
This addon doesn't use htmlbars directly (only for tests), so no need for it to be in direct dependencies.

### Testing Done ###
All tests passed locally