### PR TITLE
Remove unused broccoli magic

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,32 +24,7 @@ module.exports = {
     var app = this.app || this._findHost();
 
     if (this._shouldInclude()) {
-      app.import(
-        'vendor/ember-cli-deprecation-workflow/deprecation-workflow.js',
-      );
       app.import('vendor/ember-cli-deprecation-workflow/main.js');
     }
-  },
-
-  treeForVendor(tree) {
-    var root = process.env._DUMMY_CONFIG_ROOT_PATH || this.project.root;
-    var configDir = '/config';
-
-    if (
-      this.project.pkg['ember-addon'] &&
-      this.project.pkg['ember-addon']['configPath']
-    ) {
-      configDir = '/' + this.project.pkg['ember-addon']['configPath'];
-    }
-
-    var mergeTrees = require('broccoli-merge-trees');
-    var Funnel = require('broccoli-funnel');
-    var configTree = new Funnel(root + configDir, {
-      include: ['deprecation-workflow.js'],
-
-      destDir: 'ember-cli-deprecation-workflow',
-    });
-
-    return mergeTrees([tree, configTree], { overwrite: true });
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
       "dependencies": {
         "@babel/core": "^7.23.2",
         "@ember/string": "^3.0.0",
-        "broccoli-funnel": "^3.0.3",
-        "broccoli-merge-trees": "^4.2.0",
-        "broccoli-plugin": "^4.0.5",
         "ember-cli-babel": "^8.2.0"
       },
       "devDependencies": {
@@ -7475,6 +7472,7 @@
     },
     "node_modules/broccoli-merge-trees": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "broccoli-plugin": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
   "dependencies": {
     "@babel/core": "^7.23.2",
     "@ember/string": "^3.0.0",
-    "broccoli-funnel": "^3.0.3",
-    "broccoli-merge-trees": "^4.2.0",
-    "broccoli-plugin": "^4.0.5",
     "ember-cli-babel": "^8.2.0"
   },
   "devDependencies": {

--- a/vendor/ember-cli-deprecation-workflow/deprecation-workflow.js
+++ b/vendor/ember-cli-deprecation-workflow/deprecation-workflow.js
@@ -1,1 +1,0 @@
-// default config/deprecation-workflow.js


### PR DESCRIPTION
#159 first removed all the broccoli usage, then brought it back, I believe to bring back https://github.com/mixonic/ember-cli-deprecation-workflow/blob/master/vendor/ember-cli-deprecation-workflow/main.js. But actually the custom broccoli magic does not seem needed anymore, especially no need to bring in the `config/deprecation-workflow.js` file into the vendor tree anymore.